### PR TITLE
lnd: fix resources block indentation

### DIFF
--- a/charts/lnd/templates/deployment.yaml
+++ b/charts/lnd/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           command: ["lnd"]
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           resources:
-  {{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.resources | indent 12 }}
           ports:
             - name: rpc
               containerPort: {{ .Values.internalServices.rpcPort }}


### PR DESCRIPTION
Currently the indentation of the resources block is messed up if it is specified.